### PR TITLE
fix: caddyfile reverse proxy syntax

### DIFF
--- a/tutors3scorm/patches/caddyfile-cms
+++ b/tutors3scorm/patches/caddyfile-cms
@@ -1,6 +1,7 @@
 handle /scorm/* {
     reverse_proxy {
-        to {{ "https" if S3SCORM_USE_SSL else "http" }}://{{ S3SCORM_BUCKET }}.{{ S3SCORM_ENDPOINT }}{{ S3SCORM_PATH }}
+        to {{ "https" if S3SCORM_USE_SSL else "http" }}://{{ S3SCORM_BUCKET }}.{{ S3SCORM_ENDPOINT }}
+        uri {{ S3SCORM_PATH }}{uri}
         header_up Host {upstream_hostport}
     }
 }

--- a/tutors3scorm/patches/caddyfile-lms
+++ b/tutors3scorm/patches/caddyfile-lms
@@ -1,6 +1,7 @@
 handle /scorm/* {
     reverse_proxy {
-        to {{ "https" if S3SCORM_USE_SSL else "http" }}://{{ S3SCORM_BUCKET }}.{{ S3SCORM_ENDPOINT }}{{ S3SCORM_PATH }}
+        to {{ "https" if S3SCORM_USE_SSL else "http" }}://{{ S3SCORM_BUCKET }}.{{ S3SCORM_ENDPOINT }}
+        uri {{ S3SCORM_PATH }}{uri}
         header_up Host {upstream_hostport}
     }
 }


### PR DESCRIPTION
Resolves the error:
`Error during parsing: parsing caddyfile tokens for 'reverse_proxy': /etc/caddy/Caddyfile:61 - Error during parsing: for now, URLs for proxy upstreams only support scheme, host, and port components, import chain: [''], import chain: ['']
`
YT:
- https://youtrack.raccoongang.com/issue/PhU-332